### PR TITLE
add .conf extension, to clarify it's needed for DKMS to workwq

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,11 +185,11 @@ the updated '.config' file back to the build file 'config'.
   sign modules is to make a soft link:
 
   $ cd /etc/dkms
-  # ln -s kernel-sign.conf <package-name>
+  # ln -s kernel-sign.conf <package-name>.conf
 
   For example:
 
-  # ln -s kernel-sign.conf virtualbox
+  # ln -s kernel-sign.conf virtualbox.conf
 
   The link creation can easily be added to an arch package to simplify further if desired.
 


### PR DESCRIPTION
Hello,

I use ARCH-SKM with a custom kernel and it works great! I got trouble with one point during the setup: in order to get DKMS to sign the modules, there needs to be a ".conf" extension on the symbolic links.

Greetings

Mathse