### PR TITLE
Fix -v argument help text f-string

### DIFF
--- a/certs-local/genkeys.py
+++ b/certs-local/genkeys.py
@@ -86,7 +86,7 @@ class GenKeys :
 
         par.add_argument('-v',  '--verb',
                 action='store_true', default = self.verb,
-                help='Verbose ({self.verb})')
+                help=f'Verbose ({self.verb})')
 
         parsed = par.parse_args()
         if parsed:


### PR DESCRIPTION
Prior to this, the help description shown for the `-v, --verb` option when running `./genkeys.py --help` would appear literally as `Verbose ({self.verb})`, which is not intended.